### PR TITLE
feat: improve mobile responsiveness

### DIFF
--- a/src/components/dashboard/CattleDashboard.tsx
+++ b/src/components/dashboard/CattleDashboard.tsx
@@ -54,7 +54,7 @@ export const CattleDashboard = () => {
           activeTab={activeTab}
           onTabChange={setActiveTab}
         />
-        <div className="pt-40 flex items-center justify-center">
+        <div className="pt-32 sm:pt-40 flex items-center justify-center">
           <div className="flex items-center gap-3 text-muted-foreground">
             <Loader className="h-6 w-6 animate-spin" />
             <span className="text-lg">Cargando datos ganaderos...</span>
@@ -72,7 +72,7 @@ export const CattleDashboard = () => {
           activeTab={activeTab}
           onTabChange={setActiveTab}
         />
-        <div className="pt-40 flex items-center justify-center">
+        <div className="pt-32 sm:pt-40 flex items-center justify-center">
           <div className="text-center">
             <h2 className="text-2xl font-bold text-destructive mb-2">Error al cargar datos</h2>
             <p className="text-muted-foreground">{error}</p>
@@ -93,7 +93,7 @@ export const CattleDashboard = () => {
         }}
       />
       
-      <main className="container mx-auto px-6 py-8 pt-40">
+      <main className="container mx-auto px-4 py-8 pt-32 sm:px-6 sm:pt-40">
         <TabContent
           tabId={activeTab}
           animalData={animalData}

--- a/src/components/dashboard/MetricasFilterSection.tsx
+++ b/src/components/dashboard/MetricasFilterSection.tsx
@@ -61,13 +61,13 @@ export const MetricasFilterSection = ({
 
   return (
     <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 shadow-sm">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-6">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:gap-6">
           {/* Filtro de Año */}
           <div className="flex items-center gap-3">
             <label className="text-amber-900 font-medium text-sm">Año de Análisis:</label>
-            <select 
-              className="bg-white border border-amber-300 rounded-md px-3 py-2 text-amber-900 font-semibold text-sm focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-amber-500"
+            <select
+              className="w-full sm:w-auto bg-white border border-amber-300 rounded-md px-3 py-2 text-amber-900 font-semibold text-sm focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-amber-500"
               value={selectedYear}
               onChange={(e) => onYearChange(parseInt(e.target.value))}
             >
@@ -102,7 +102,7 @@ export const MetricasFilterSection = ({
             />
           </div>
         </div>
-        
+
         <div className="flex items-center gap-2">
           <Calendar className="h-6 w-6 text-amber-600" />
           <MapPin className="h-6 w-6 text-amber-600" />

--- a/src/components/dashboard/MunicipiosFilterSection.tsx
+++ b/src/components/dashboard/MunicipiosFilterSection.tsx
@@ -33,13 +33,13 @@ export const MunicipiosFilterSection = ({
 
   return (
     <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 shadow-sm">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-6">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:gap-6">
           {/* Filtro de Año */}
           <div className="flex items-center gap-3">
             <label className="text-amber-900 font-medium text-sm">Año de Análisis:</label>
-            <select 
-              className="bg-white border border-amber-300 rounded-md px-3 py-2 text-amber-900 font-semibold text-sm focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-amber-500"
+            <select
+              className="w-full sm:w-auto bg-white border border-amber-300 rounded-md px-3 py-2 text-amber-900 font-semibold text-sm focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-amber-500"
               value={selectedYear}
               onChange={(e) => onYearChange(parseInt(e.target.value))}
             >
@@ -62,7 +62,7 @@ export const MunicipiosFilterSection = ({
             />
           </div>
         </div>
-        
+
         <div className="flex items-center gap-2">
           <Calendar className="h-6 w-6 text-amber-600" />
           <MapPin className="h-6 w-6 text-amber-600" />

--- a/src/components/dashboard/UnifiedNavigation.tsx
+++ b/src/components/dashboard/UnifiedNavigation.tsx
@@ -130,14 +130,14 @@ export const UnifiedNavigation = ({ tabs, activeTab, onTabChange }: UnifiedNavig
     <nav className="fixed top-0 left-0 right-0 z-50 shadow-lg">
       {/* Header Section */}
       <div className="bg-white border-b border-border">
-        <div className="container mx-auto px-6 py-3">
-          <div className="flex items-center justify-center gap-3">
-            <img 
-              src={cattleIcon} 
+        <div className="container mx-auto px-4 py-2 sm:px-6 sm:py-3">
+          <div className="flex flex-col items-center justify-center gap-2 sm:flex-row sm:gap-3">
+            <img
+              src={cattleIcon}
               alt="Cattle Analysis"
-              className="w-20 h-20 object-contain drop-shadow-sm rounded-full bg-white/10 p-2"
+              className="w-16 h-16 p-1 sm:w-20 sm:h-20 sm:p-2 object-contain drop-shadow-sm rounded-full bg-white/10"
             />
-            <h1 className="text-2xl font-bold text-foreground tracking-wide">
+            <h1 className="text-lg font-bold text-center sm:text-left sm:text-2xl text-foreground tracking-wide">
               Sistema de Análisis Ganadero Bovino
             </h1>
           </div>
@@ -146,7 +146,7 @@ export const UnifiedNavigation = ({ tabs, activeTab, onTabChange }: UnifiedNavig
       
       {/* Tabs Section */}
       <div className="bg-primary relative overflow-hidden border-0">
-        <div className="container mx-auto px-6 py-1.5 border-0">
+        <div className="container mx-auto px-2 py-1 sm:px-6 sm:py-1.5 border-0">
         <DndContext
           sensors={sensors}
           collisionDetection={closestCenter}

--- a/src/components/dashboard/YearFilterSection.tsx
+++ b/src/components/dashboard/YearFilterSection.tsx
@@ -13,11 +13,11 @@ export const YearFilterSection = ({
 }: YearFilterSectionProps) => {
   return (
     <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 shadow-sm">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3">
           <label className="text-amber-900 font-medium text-sm">Año de Análisis:</label>
-          <select 
-            className="bg-white border border-amber-300 rounded-md px-3 py-2 text-amber-900 font-semibold text-sm focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-amber-500"
+          <select
+            className="w-full sm:w-auto bg-white border border-amber-300 rounded-md px-3 py-2 text-amber-900 font-semibold text-sm focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-amber-500"
             value={selectedYear}
             onChange={(e) => onYearChange(parseInt(e.target.value))}
           >


### PR DESCRIPTION
## Summary
- refine navigation layout for smaller viewports
- adjust dashboard spacing for mobile screens
- ensure filter sections stack on small devices

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0c669a2ac8328a6a5569842935b3d