### PR TITLE
feat: add language switch with simple i18n

### DIFF
--- a/src/components/dashboard/CattleDashboard.tsx
+++ b/src/components/dashboard/CattleDashboard.tsx
@@ -4,30 +4,32 @@ import { UnifiedNavigation } from './UnifiedNavigation';
 import { TabContent } from './TabContent';
 import { TabItem } from '@/types/dashboard';
 import { Loader } from 'lucide-react';
+import { useI18n } from '@/lib/i18n';
 
 export const CattleDashboard = () => {
   const { animalData, farmData, loading, error } = useCSVData();
   const [activeTab, setActiveTab] = useState('metricas-generales');
+  const { t } = useI18n();
 
   const tabs: TabItem[] = [
     {
       id: 'metricas-generales',
-      title: 'Análisis Ganadero Nacional',
+      title: t('tabs.general'),
       content: null
     },
     {
       id: 'departamento',
-      title: 'Departamento',
+      title: t('tabs.department'),
       content: null
     },
     {
       id: 'municipios',
-      title: 'Municipios',
+      title: t('tabs.municipalities'),
       content: null
     },
     {
       id: 'fuente-datos',
-      title: 'Fuente de Datos',
+      title: t('tabs.dataSource'),
       content: null
     }
   ];
@@ -57,7 +59,7 @@ export const CattleDashboard = () => {
         <div className="pt-40 flex items-center justify-center">
           <div className="flex items-center gap-3 text-muted-foreground">
             <Loader className="h-6 w-6 animate-spin" />
-            <span className="text-lg">Cargando datos ganaderos...</span>
+            <span className="text-lg">{t('loading')}</span>
           </div>
         </div>
       </div>
@@ -74,7 +76,7 @@ export const CattleDashboard = () => {
         />
         <div className="pt-40 flex items-center justify-center">
           <div className="text-center">
-            <h2 className="text-2xl font-bold text-destructive mb-2">Error al cargar datos</h2>
+            <h2 className="text-2xl font-bold text-destructive mb-2">{t('errorTitle')}</h2>
             <p className="text-muted-foreground">{error}</p>
           </div>
         </div>

--- a/src/components/dashboard/DashboardHeader.tsx
+++ b/src/components/dashboard/DashboardHeader.tsx
@@ -1,19 +1,25 @@
-import { Activity } from 'lucide-react';
 import cattleIcon from '@/assets/cattle-icon.png';
+import { useI18n } from '@/lib/i18n';
 
 export const DashboardHeader = () => {
+  const { t, lang, toggle } = useI18n();
   return (
     <header className="bg-card border-b-0 shadow-md fixed top-0 left-0 right-0 z-50">
       <div className="container mx-auto px-6 py-3">
-        <div className="flex items-center justify-center gap-3">
-          <img 
-            src={cattleIcon} 
-            alt="Cattle Analysis"
-            className="w-10 h-10 object-contain drop-shadow-sm"
-          />
-          <h1 className="text-2xl font-bold text-foreground tracking-wide">
-            Sistema de Análisis Ganadero Bovino
-          </h1>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <img
+              src={cattleIcon}
+              alt="Cattle Analysis"
+              className="w-10 h-10 object-contain drop-shadow-sm"
+            />
+            <h1 className="text-2xl font-bold text-foreground tracking-wide">
+              {t('app.title')}
+            </h1>
+          </div>
+          <button onClick={toggle} className="px-3 py-1 text-sm border rounded">
+            {lang === 'en' ? 'ES' : 'EN'}
+          </button>
         </div>
       </div>
     </header>

--- a/src/components/dashboard/UnifiedNavigation.tsx
+++ b/src/components/dashboard/UnifiedNavigation.tsx
@@ -23,6 +23,7 @@ import { CSS } from '@dnd-kit/utilities';
 import { cn } from '@/lib/utils';
 import { TabItem } from '@/types/dashboard';
 import { GripVertical, MapPin, Building, Map } from 'lucide-react';
+import { useI18n } from '@/lib/i18n';
 
 const getTabIcon = (tabId: string) => {
   switch (tabId) {
@@ -101,6 +102,7 @@ interface UnifiedNavigationProps {
 
 export const UnifiedNavigation = ({ tabs, activeTab, onTabChange }: UnifiedNavigationProps) => {
   const [tabItems, setTabItems] = useState(tabs);
+  const { t, lang, toggle } = useI18n();
   
   useEffect(() => {
     setTabItems(tabs);
@@ -131,15 +133,23 @@ export const UnifiedNavigation = ({ tabs, activeTab, onTabChange }: UnifiedNavig
       {/* Header Section */}
       <div className="bg-white border-b border-border">
         <div className="container mx-auto px-6 py-3">
-          <div className="flex items-center justify-center gap-3">
-            <img 
-              src={cattleIcon} 
-              alt="Cattle Analysis"
-              className="w-20 h-20 object-contain drop-shadow-sm rounded-full bg-white/10 p-2"
-            />
-            <h1 className="text-2xl font-bold text-foreground tracking-wide">
-              Sistema de Análisis Ganadero Bovino
-            </h1>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <img
+                src={cattleIcon}
+                alt="Cattle Analysis"
+                className="w-20 h-20 object-contain drop-shadow-sm rounded-full bg-white/10 p-2"
+              />
+              <h1 className="text-2xl font-bold text-foreground tracking-wide">
+                {t('app.title')}
+              </h1>
+            </div>
+            <button
+              onClick={toggle}
+              className="px-3 py-1 text-sm border rounded"
+            >
+              {lang === 'en' ? 'ES' : 'EN'}
+            </button>
           </div>
         </div>
       </div>

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -1,0 +1,80 @@
+import { createContext, useContext, useState, type ReactNode } from 'react';
+
+type Language = 'en' | 'es';
+
+interface I18nContextValue {
+  lang: Language;
+  t: (key: string) => string;
+  toggle: () => void;
+}
+
+interface Translations {
+  app: { title: string };
+  tabs: {
+    general: string;
+    department: string;
+    municipalities: string;
+    dataSource: string;
+  };
+  loading: string;
+  errorTitle: string;
+}
+
+const translations: Record<Language, Translations> = {
+  en: {
+    app: { title: 'Bovine Livestock Analysis System' },
+    tabs: {
+      general: 'National Livestock Analysis',
+      department: 'Department',
+      municipalities: 'Municipalities',
+      dataSource: 'Data Source'
+    },
+    loading: 'Loading livestock data...',
+    errorTitle: 'Error loading data'
+  },
+  es: {
+    app: { title: 'Sistema de Análisis Ganadero Bovino' },
+    tabs: {
+      general: 'Análisis Ganadero Nacional',
+      department: 'Departamento',
+      municipalities: 'Municipios',
+      dataSource: 'Fuente de Datos'
+    },
+    loading: 'Cargando datos ganaderos...',
+    errorTitle: 'Error al cargar datos'
+  }
+};
+
+const I18nContext = createContext<I18nContextValue>({
+  lang: 'en',
+  t: (key: string) => key,
+  toggle: () => {}
+});
+
+export const I18nProvider = ({ children }: { children: ReactNode }) => {
+  const [lang, setLang] = useState<Language>('en');
+
+  const t = (key: string): string => {
+    const parts = key.split('.');
+    let result: unknown = translations[lang];
+    for (const part of parts) {
+      if (typeof result === 'object' && result !== null && part in result) {
+        result = (result as Record<string, unknown>)[part];
+      } else {
+        return key;
+      }
+    }
+    return typeof result === 'string' ? result : key;
+  };
+
+  const toggle = () => setLang(prev => (prev === 'en' ? 'es' : 'en'));
+
+  return (
+    <I18nContext.Provider value={{ lang, t, toggle }}>
+      {children}
+    </I18nContext.Provider>
+  );
+};
+
+export const useI18n = () => useContext(I18nContext);
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,10 @@
-import { createRoot } from 'react-dom/client'
-import App from './App.tsx'
-import './index.css'
+import { createRoot } from 'react-dom/client';
+import App from './App.tsx';
+import './index.css';
+import { I18nProvider } from './lib/i18n';
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById('root')!).render(
+  <I18nProvider>
+    <App />
+  </I18nProvider>
+);


### PR DESCRIPTION
## Summary
- add lightweight i18n context with English and Spanish dictionaries
- wrap app with provider and translate dashboard texts
- add header button to toggle between ES and EN

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c8f25a248328b922f05de4b5a5f0