### PR TITLE
Add basic internationalization with language toggle

### DIFF
--- a/src/components/dashboard/ActiveFiltersTags.tsx
+++ b/src/components/dashboard/ActiveFiltersTags.tsx
@@ -1,4 +1,5 @@
 import { X, Calendar, MapPin, Building } from 'lucide-react';
+import { useI18n } from '@/lib/i18n';
 
 interface ActiveFiltersTagsProps {
   selectedYear: number;
@@ -15,6 +16,7 @@ export const ActiveFiltersTags = ({
   onClearDepartamento,
   onClearMunicipio
 }: ActiveFiltersTagsProps) => {
+  const { t } = useI18n();
   const hasActiveFilters = selectedDepartamento || selectedMunicipio;
 
   if (!hasActiveFilters) {
@@ -27,7 +29,7 @@ export const ActiveFiltersTags = ({
         <div className="bg-amber-600 rounded-full p-1">
           <Calendar className="h-3 w-3 text-white" />
         </div>
-        <span className="text-xs font-medium text-amber-800">Filtros Activos:</span>
+        <span className="text-xs font-medium text-amber-800">{t('filters.active')}</span>
       </div>
       
       <div className="flex flex-wrap gap-2">
@@ -35,7 +37,7 @@ export const ActiveFiltersTags = ({
         <div className="flex items-center gap-1.5 bg-amber-100 border border-amber-300 rounded-full px-3 py-1.5">
           <Calendar className="h-3 w-3 text-amber-700" />
           <span className="text-xs font-medium text-amber-800">
-            Año {selectedYear}
+            {t('filters.yearTag', { year: selectedYear })}
           </span>
         </div>
 
@@ -49,7 +51,7 @@ export const ActiveFiltersTags = ({
             <button
               onClick={onClearDepartamento}
               className="ml-1 hover:bg-blue-200 rounded-full p-0.5 transition-colors"
-              title="Limpiar departamento"
+              title={t('filters.clearDepartment')}
             >
               <X className="h-3 w-3 text-blue-600" />
             </button>
@@ -66,7 +68,7 @@ export const ActiveFiltersTags = ({
             <button
               onClick={onClearMunicipio}
               className="ml-1 hover:bg-green-200 rounded-full p-0.5 transition-colors"
-              title="Limpiar municipio"
+              title={t('filters.clearMunicipality')}
             >
               <X className="h-3 w-3 text-green-600" />
             </button>

--- a/src/components/dashboard/CattleDashboard.tsx
+++ b/src/components/dashboard/CattleDashboard.tsx
@@ -4,30 +4,32 @@ import { UnifiedNavigation } from './UnifiedNavigation';
 import { TabContent } from './TabContent';
 import { TabItem } from '@/types/dashboard';
 import { Loader } from 'lucide-react';
+import { useI18n } from '@/lib/i18n';
 
 export const CattleDashboard = () => {
   const { animalData, farmData, loading, error } = useCSVData();
   const [activeTab, setActiveTab] = useState('metricas-generales');
+  const { t } = useI18n();
 
   const tabs: TabItem[] = [
     {
       id: 'metricas-generales',
-      title: 'Análisis Ganadero Nacional',
+      title: t('tabs.national'),
       content: null
     },
     {
       id: 'departamento',
-      title: 'Departamento',
+      title: t('tabs.department'),
       content: null
     },
     {
       id: 'municipios',
-      title: 'Municipios',
+      title: t('tabs.municipalities'),
       content: null
     },
     {
       id: 'fuente-datos',
-      title: 'Fuente de Datos',
+      title: t('tabs.dataSource'),
       content: null
     }
   ];
@@ -57,7 +59,7 @@ export const CattleDashboard = () => {
         <div className="pt-32 sm:pt-40 flex items-center justify-center">
           <div className="flex items-center gap-3 text-muted-foreground">
             <Loader className="h-6 w-6 animate-spin" />
-            <span className="text-lg">Cargando datos ganaderos...</span>
+            <span className="text-lg">{t('loading')}</span>
           </div>
         </div>
       </div>
@@ -74,7 +76,7 @@ export const CattleDashboard = () => {
         />
         <div className="pt-32 sm:pt-40 flex items-center justify-center">
           <div className="text-center">
-            <h2 className="text-2xl font-bold text-destructive mb-2">Error al cargar datos</h2>
+            <h2 className="text-2xl font-bold text-destructive mb-2">{t('error.title')}</h2>
             <p className="text-muted-foreground">{error}</p>
           </div>
         </div>

--- a/src/components/dashboard/MetricasFilterSection.tsx
+++ b/src/components/dashboard/MetricasFilterSection.tsx
@@ -1,6 +1,7 @@
 import { Calendar, MapPin, Building } from 'lucide-react';
 import { AnimalData } from '@/types/dashboard';
 import { SearchSelect } from '@/components/ui/search-select';
+import { useI18n } from '@/lib/i18n';
 
 interface MetricasFilterSectionProps {
   selectedYear: number;
@@ -25,10 +26,12 @@ export const MetricasFilterSection = ({
 }: MetricasFilterSectionProps) => {
   // Obtener departamentos únicos de los datos
   const departamentos = Array.from(new Set(animalData.map(d => d.DEPARTAMENTO))).sort();
-  
+
   // Convertir a formato para SearchSelect
+  const { t } = useI18n();
+
   const departamentoOptions = [
-    { value: '', label: 'Todos los Departamentos' },
+    { value: '', label: t('filters.allDepartments') },
     ...departamentos.map(departamento => ({
       value: departamento,
       label: departamento.charAt(0).toUpperCase() + departamento.slice(1).toLowerCase()
@@ -46,7 +49,7 @@ export const MetricasFilterSection = ({
     
   // Convertir municipios a formato para SearchSelect
   const municipioOptions = [
-    { value: '', label: selectedDepartamento ? 'Todos los Municipios' : 'Seleccione un Departamento' },
+    { value: '', label: selectedDepartamento ? t('filters.allMunicipalities') : t('filters.selectDepartment') },
     ...municipiosDelDepartamento.map(municipio => ({
       value: municipio,
       label: municipio.charAt(0).toUpperCase() + municipio.slice(1).toLowerCase()
@@ -65,7 +68,7 @@ export const MetricasFilterSection = ({
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:gap-6">
           {/* Filtro de Año */}
           <div className="flex items-center gap-3">
-            <label className="text-amber-900 font-medium text-sm">Año de Análisis:</label>
+            <label className="text-amber-900 font-medium text-sm">{t('filters.year')}</label>
             <select
               className="w-full sm:w-auto bg-white border border-amber-300 rounded-md px-3 py-2 text-amber-900 font-semibold text-sm focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-amber-500"
               value={selectedYear}
@@ -81,23 +84,23 @@ export const MetricasFilterSection = ({
 
           {/* Filtro de Departamento */}
           <div className="flex items-center gap-3">
-            <label className="text-amber-900 font-medium text-sm">Departamento:</label>
+            <label className="text-amber-900 font-medium text-sm">{t('filters.department')}</label>
             <SearchSelect
               value={selectedDepartamento}
               onChange={handleDepartamentoChange}
               options={departamentoOptions}
-              placeholder="Todos los Departamentos"
+              placeholder={t('filters.allDepartments')}
             />
           </div>
 
           {/* Filtro de Municipio */}
           <div className="flex items-center gap-3">
-            <label className="text-amber-900 font-medium text-sm">Municipio:</label>
+            <label className="text-amber-900 font-medium text-sm">{t('filters.municipality')}</label>
             <SearchSelect
               value={selectedMunicipio}
               onChange={onMunicipioChange}
               options={municipioOptions}
-              placeholder={selectedDepartamento ? "Todos los Municipios" : "Seleccione un Departamento"}
+              placeholder={selectedDepartamento ? t('filters.allMunicipalities') : t('filters.selectDepartment')}
               disabled={!selectedDepartamento}
             />
           </div>

--- a/src/components/dashboard/MetricsSection.tsx
+++ b/src/components/dashboard/MetricsSection.tsx
@@ -1,5 +1,6 @@
 import { AnimalData, FarmData } from '@/types/dashboard';
 import { KPICards } from './KPICards';
+import { useI18n } from '@/lib/i18n';
 
 interface MetricsSectionProps {
   animalData: AnimalData[];
@@ -8,12 +9,13 @@ interface MetricsSectionProps {
 }
 
 export const MetricsSection = ({ animalData, farmData, selectedYear }: MetricsSectionProps) => {
+  const { t } = useI18n();
   return (
     <div className="bg-white p-6 rounded-lg shadow-lg border border-amber-100">
       <h3 className="text-lg font-semibold text-amber-950 mb-4 text-left">
-        Métricas Generales
+        {t('metrics.general')}
       </h3>
-      <KPICards 
+      <KPICards
         animalData={animalData}
         farmData={farmData}
         selectedYear={selectedYear}

--- a/src/components/dashboard/MunicipiosFilterSection.tsx
+++ b/src/components/dashboard/MunicipiosFilterSection.tsx
@@ -1,6 +1,7 @@
 import { Calendar, MapPin } from 'lucide-react';
 import { AnimalData } from '@/types/dashboard';
 import { SearchSelect } from '@/components/ui/search-select';
+import { useI18n } from '@/lib/i18n';
 
 interface MunicipiosFilterSectionProps {
   selectedYear: number;
@@ -11,9 +12,9 @@ interface MunicipiosFilterSectionProps {
   animalData: AnimalData[];
 }
 
-export const MunicipiosFilterSection = ({ 
-  selectedYear, 
-  onYearChange, 
+export const MunicipiosFilterSection = ({
+  selectedYear,
+  onYearChange,
   availableYears,
   selectedDepartamento,
   onDepartamentoChange,
@@ -23,8 +24,10 @@ export const MunicipiosFilterSection = ({
   const departamentos = Array.from(new Set(animalData.map(d => d.DEPARTAMENTO))).sort();
   
   // Convertir a formato para SearchSelect
+  const { t } = useI18n();
+
   const departamentoOptions = [
-    { value: '', label: 'Todos los Departamentos' },
+    { value: '', label: t('filters.allDepartments') },
     ...departamentos.map(departamento => ({
       value: departamento,
       label: departamento.charAt(0).toUpperCase() + departamento.slice(1).toLowerCase()
@@ -37,7 +40,7 @@ export const MunicipiosFilterSection = ({
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:gap-6">
           {/* Filtro de Año */}
           <div className="flex items-center gap-3">
-            <label className="text-amber-900 font-medium text-sm">Año de Análisis:</label>
+            <label className="text-amber-900 font-medium text-sm">{t('filters.year')}</label>
             <select
               className="w-full sm:w-auto bg-white border border-amber-300 rounded-md px-3 py-2 text-amber-900 font-semibold text-sm focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-amber-500"
               value={selectedYear}
@@ -53,12 +56,12 @@ export const MunicipiosFilterSection = ({
 
           {/* Filtro de Departamento */}
           <div className="flex items-center gap-3">
-            <label className="text-amber-900 font-medium text-sm">Departamento:</label>
+            <label className="text-amber-900 font-medium text-sm">{t('filters.department')}</label>
             <SearchSelect
               value={selectedDepartamento}
               onChange={onDepartamentoChange}
               options={departamentoOptions}
-              placeholder="Todos los Departamentos"
+              placeholder={t('filters.allDepartments')}
             />
           </div>
         </div>

--- a/src/components/dashboard/TabContent.tsx
+++ b/src/components/dashboard/TabContent.tsx
@@ -11,6 +11,7 @@ import { AnalisisDetallado } from './AnalisisDetallado';
 import { ActiveFiltersTags } from './ActiveFiltersTags';
 import { procesarDatosBovinos } from '@/utils/dataProcessor';
 import { useState } from 'react';
+import { useI18n } from '@/lib/i18n';
 
 interface TabContentProps {
   tabId: string;
@@ -30,7 +31,7 @@ export const TabContent = ({
   availableYears 
 }: TabContentProps) => {
   console.log('TabContent render - tabId:', tabId);
-  
+
   // Estado para el departamento seleccionado en la tab de municipios
   const [selectedDepartamento, setSelectedDepartamento] = useState<string>('');
   
@@ -38,18 +39,20 @@ export const TabContent = ({
   const [selectedDepartamentoMetricas, setSelectedDepartamentoMetricas] = useState<string>('');
   const [selectedMunicipioMetricas, setSelectedMunicipioMetricas] = useState<string>('');
   
+  const { t } = useI18n();
+
   const getTabTitle = () => {
     switch (tabId) {
       case 'departamento':
-        return 'Información por Departamento';
+        return t('tabs.department');
       case 'municipios':
-        return 'Información por Municipios';
+        return t('tabs.municipalities');
       case 'metricas-generales':
-        return 'Análisis Ganadero Nacional';
+        return t('tabs.national');
       case 'fuente-datos':
-        return 'Fuente de Datos';
+        return t('tabs.dataSource');
       default:
-        return 'Información por Departamento';
+        return t('tabs.department');
     }
   };
 
@@ -99,7 +102,7 @@ export const TabContent = ({
           <div className="bg-white rounded-lg shadow p-4">
             <div className="bg-amber-50 border border-amber-200 rounded-lg p-3 mb-4">
               <h3 className="text-sm font-medium text-amber-900 text-center">
-                Ranking por Departamento - {selectedYear}
+                {t('rankings.department', { year: selectedYear })}
               </h3>
             </div>
             <RankingDepartamentos 
@@ -183,7 +186,7 @@ export const TabContent = ({
           <div className="bg-white rounded-lg shadow p-4">
             <div className="bg-amber-50 border border-amber-200 rounded-lg p-3 mb-4">
               <h3 className="text-sm font-medium text-amber-900 text-center">
-                Ranking por Municipio - {selectedYear}
+                {t('rankings.municipality', { year: selectedYear })}
               </h3>
             </div>
             <RankingMunicipios 

--- a/src/components/dashboard/UnifiedNavigation.tsx
+++ b/src/components/dashboard/UnifiedNavigation.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react';
 import { Activity } from 'lucide-react';
 import cattleIcon from '@/assets/cattle-icon.png';
+import { Button } from '@/components/ui/button';
+import { useI18n } from '@/lib/i18n';
 import {
   DndContext,
   closestCenter,
@@ -101,7 +103,8 @@ interface UnifiedNavigationProps {
 
 export const UnifiedNavigation = ({ tabs, activeTab, onTabChange }: UnifiedNavigationProps) => {
   const [tabItems, setTabItems] = useState(tabs);
-  
+  const { t, lang, toggleLanguage } = useI18n();
+
   useEffect(() => {
     setTabItems(tabs);
   }, [tabs]);
@@ -131,15 +134,20 @@ export const UnifiedNavigation = ({ tabs, activeTab, onTabChange }: UnifiedNavig
       {/* Header Section */}
       <div className="bg-white border-b border-border">
         <div className="container mx-auto px-4 py-2 sm:px-6 sm:py-3">
-          <div className="flex flex-col items-center justify-center gap-2 sm:flex-row sm:gap-3">
-            <img
-              src={cattleIcon}
-              alt="Cattle Analysis"
-              className="w-16 h-16 p-1 sm:w-20 sm:h-20 sm:p-2 object-contain drop-shadow-sm rounded-full bg-white/10"
-            />
-            <h1 className="text-lg font-bold text-center sm:text-left sm:text-2xl text-foreground tracking-wide">
-              Sistema de Análisis Ganadero Bovino
-            </h1>
+          <div className="flex flex-col items-center justify-center gap-2 sm:flex-row sm:justify-between sm:gap-3">
+            <div className="flex items-center gap-3">
+              <img
+                src={cattleIcon}
+                alt="Cattle Analysis"
+                className="w-16 h-16 p-1 sm:w-20 sm:h-20 sm:p-2 object-contain drop-shadow-sm rounded-full bg-white/10"
+              />
+              <h1 className="text-lg font-bold text-center sm:text-left sm:text-2xl text-foreground tracking-wide">
+                {t('header.title')}
+              </h1>
+            </div>
+            <Button variant="outline" size="sm" onClick={toggleLanguage} className="mt-2 sm:mt-0">
+              {lang === 'en' ? 'ES' : 'EN'}
+            </Button>
           </div>
         </div>
       </div>

--- a/src/components/dashboard/YearFilterSection.tsx
+++ b/src/components/dashboard/YearFilterSection.tsx
@@ -1,4 +1,5 @@
 import { Calendar } from 'lucide-react';
+import { useI18n } from '@/lib/i18n';
 
 interface YearFilterSectionProps {
   selectedYear: number;
@@ -6,16 +7,17 @@ interface YearFilterSectionProps {
   availableYears: number[];
 }
 
-export const YearFilterSection = ({ 
-  selectedYear, 
-  onYearChange, 
-  availableYears 
+export const YearFilterSection = ({
+  selectedYear,
+  onYearChange,
+  availableYears
 }: YearFilterSectionProps) => {
+  const { t } = useI18n();
   return (
     <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 shadow-sm">
       <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3">
-          <label className="text-amber-900 font-medium text-sm">Año de Análisis:</label>
+          <label className="text-amber-900 font-medium text-sm">{t('filters.year')}</label>
           <select
             className="w-full sm:w-auto bg-white border border-amber-300 rounded-md px-3 py-2 text-amber-900 font-semibold text-sm focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-amber-500"
             value={selectedYear}

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -1,0 +1,115 @@
+import { createContext, ReactNode, useContext, useState } from 'react';
+
+type Language = 'en' | 'es';
+
+const resources = {
+  en: {
+    header: {
+      title: 'Bovine Livestock Analysis System'
+    },
+    tabs: {
+      national: 'National Livestock Analysis',
+      department: 'Department',
+      municipalities: 'Municipalities',
+      dataSource: 'Data Source'
+    },
+    loading: 'Loading cattle data...',
+    error: {
+      title: 'Error loading data'
+    },
+    rankings: {
+      department: 'Department Ranking - {{year}}',
+      municipality: 'Municipality Ranking - {{year}}'
+    },
+    filters: {
+      year: 'Year of Analysis:',
+      department: 'Department:',
+      allDepartments: 'All Departments',
+      municipality: 'Municipality:',
+      allMunicipalities: 'All Municipalities',
+      selectDepartment: 'Select a Department',
+      active: 'Active Filters:',
+      yearTag: 'Year {{year}}',
+      clearDepartment: 'Clear department',
+      clearMunicipality: 'Clear municipality'
+    },
+    metrics: {
+      general: 'General Metrics'
+    }
+  },
+  es: {
+    header: {
+      title: 'Sistema de Análisis Ganadero Bovino'
+    },
+    tabs: {
+      national: 'Análisis Ganadero Nacional',
+      department: 'Departamento',
+      municipalities: 'Municipios',
+      dataSource: 'Fuente de Datos'
+    },
+    loading: 'Cargando datos ganaderos...',
+    error: {
+      title: 'Error al cargar datos'
+    },
+    rankings: {
+      department: 'Ranking por Departamento - {{year}}',
+      municipality: 'Ranking por Municipio - {{year}}'
+    },
+    filters: {
+      year: 'Año de Análisis:',
+      department: 'Departamento:',
+      allDepartments: 'Todos los Departamentos',
+      municipality: 'Municipio:',
+      allMunicipalities: 'Todos los Municipios',
+      selectDepartment: 'Seleccione un Departamento',
+      active: 'Filtros Activos:',
+      yearTag: 'Año {{year}}',
+      clearDepartment: 'Limpiar departamento',
+      clearMunicipality: 'Limpiar municipio'
+    },
+    metrics: {
+      general: 'Métricas Generales'
+    }
+  }
+} as const;
+
+interface I18nContextProps {
+  lang: Language;
+  t: (key: string, vars?: Record<string, string | number>) => string;
+  toggleLanguage: () => void;
+}
+
+const I18nContext = createContext<I18nContextProps | undefined>(undefined);
+
+export const I18nProvider = ({ children }: { children: ReactNode }) => {
+  const [lang, setLang] = useState<Language>('en');
+
+  const t = (key: string, vars: Record<string, string | number> = {}) => {
+    const keys = key.split('.');
+    let result: unknown = resources[lang];
+    for (const k of keys) {
+      result = (result as Record<string, unknown>)[k];
+      if (result === undefined) return key;
+    }
+    if (typeof result === 'string') {
+      return result.replace(/{{(\w+)}}/g, (_, v) => String(vars[v] ?? ''));
+    }
+    return key;
+  };
+
+  const toggleLanguage = () => setLang(prev => (prev === 'en' ? 'es' : 'en'));
+
+  return (
+    <I18nContext.Provider value={{ lang, t, toggleLanguage }}>
+      {children}
+    </I18nContext.Provider>
+  );
+};
+
+export const useI18n = () => {
+  const context = useContext(I18nContext);
+  if (!context) {
+    throw new Error('useI18n must be used within an I18nProvider');
+  }
+  return context;
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,10 @@
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
+import { I18nProvider } from './lib/i18n'
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById("root")!).render(
+  <I18nProvider>
+    <App />
+  </I18nProvider>
+);


### PR DESCRIPTION
## Summary
- add lightweight i18n provider with English default and Spanish translations
- translate navigation, filters and rankings
- add header button to switch language

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type in textarea.tsx and other existing issues)*
- `npx eslint src/lib/i18n.tsx src/main.tsx src/components/dashboard/CattleDashboard.tsx src/components/dashboard/UnifiedNavigation.tsx src/components/dashboard/TabContent.tsx src/components/dashboard/MunicipiosFilterSection.tsx src/components/dashboard/MetricasFilterSection.tsx src/components/dashboard/YearFilterSection.tsx src/components/dashboard/MetricsSection.tsx src/components/dashboard/ActiveFiltersTags.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0cba815888328a991bfdd32e023c0