### PR TITLE
Add Colombia to header and improve translations

### DIFF
--- a/src/components/dashboard/AnalisisDetallado.tsx
+++ b/src/components/dashboard/AnalisisDetallado.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import * as d3 from 'd3';
 import { AnimalData } from '@/types/dashboard';
 import { Activity, Calendar, Users, PieChart, TrendingUp } from 'lucide-react';
+import { useI18n } from '@/lib/i18n';
 
 interface AnalisisDetalladoProps {
   animalData: AnimalData[];
@@ -10,6 +11,7 @@ interface AnalisisDetalladoProps {
 }
 
 export const AnalisisDetallado = ({ animalData, allAnimalData, selectedYear }: AnalisisDetalladoProps) => {
+  const { t } = useI18n();
   const barrasAnualesRef = useRef<SVGSVGElement>(null);
   const barrasApiladasRef = useRef<SVGSVGElement>(null);
   const donaEdadRef = useRef<SVGSVGElement>(null);
@@ -437,7 +439,7 @@ export const AnalisisDetallado = ({ animalData, allAnimalData, selectedYear }: A
         .attr("dy", "1em")
         .style("font-size", "12px")
         .style("fill", "#6B7280")
-        .text("Total Bovinos");
+        .text(t('charts.totalCattle'));
     }
 
     // Crear gráfico de dona por sexo
@@ -529,7 +531,7 @@ export const AnalisisDetallado = ({ animalData, allAnimalData, selectedYear }: A
         .attr("dy", "1em")
         .style("font-size", "12px")
         .style("fill", "#6B7280")
-        .text("Total Bovinos");
+        .text(t('charts.totalCattle'));
     }
 
   }, [animalData, allAnimalData, selectedYear]);
@@ -537,7 +539,7 @@ export const AnalisisDetallado = ({ animalData, allAnimalData, selectedYear }: A
   return (
     <div className="bg-white p-8 rounded-lg shadow-lg border border-amber-100">
       <h2 className="text-2xl font-bold text-amber-900 mb-6 text-center">
-        Análisis Detallado de Métricas
+        {t('charts.detailedAnalysis')}
       </h2>
       
       {/* Cuadrícula 2x2 */}
@@ -545,7 +547,7 @@ export const AnalisisDetallado = ({ animalData, allAnimalData, selectedYear }: A
         {/* Gráfico Superior Izquierdo */}
         <div className="bg-white rounded-lg p-4 border-2 border-amber-200 shadow-md relative" ref={containerAnualesRef}>
           <h3 className="text-center font-semibold mb-4 text-gray-800">
-            Número de Bovinos Anuales
+            {t('charts.annualCattle')}
           </h3>
           <div className="flex justify-center">
             <svg ref={barrasAnualesRef}></svg>
@@ -566,7 +568,7 @@ export const AnalisisDetallado = ({ animalData, allAnimalData, selectedYear }: A
                   <Calendar className="h-4 w-4 text-white" />
                 </div>
                 <h4 className="font-semibold text-amber-900 text-sm">
-                  Año {tooltipAnual.año}
+                  {t('charts.year')} {tooltipAnual.año}
                 </h4>
               </div>
               
@@ -575,7 +577,7 @@ export const AnalisisDetallado = ({ animalData, allAnimalData, selectedYear }: A
                   <Activity className="h-4 w-4 text-white" />
                 </div>
                 <div>
-                  <p className="text-xs text-amber-700 font-medium">Total Bovinos</p>
+                  <p className="text-xs text-amber-700 font-medium">{t('charts.totalCattle')}</p>
                   <p className="text-lg font-bold text-amber-900">
                     {tooltipAnual.total.toLocaleString('es-CO')}
                   </p>
@@ -588,7 +590,7 @@ export const AnalisisDetallado = ({ animalData, allAnimalData, selectedYear }: A
                     <TrendingUp className="h-4 w-4 text-white" />
                   </div>
                   <div>
-                    <p className="text-xs text-amber-700 font-medium">Crecimiento YoY</p>
+                    <p className="text-xs text-amber-700 font-medium">{t('charts.yoyGrowth')}</p>
                     <p className={`text-lg font-bold ${tooltipAnual.yoy >= 0 ? 'text-green-700' : 'text-red-700'}`}>
                       {tooltipAnual.yoy >= 0 ? '+' : ''}{tooltipAnual.yoy.toFixed(1)}%
                     </p>
@@ -602,7 +604,7 @@ export const AnalisisDetallado = ({ animalData, allAnimalData, selectedYear }: A
         {/* Gráfico Superior Derecho */}
         <div className="bg-white rounded-lg p-4 border-2 border-blue-200 shadow-md relative" ref={containerApiladasRef}>
           <h3 className="text-center font-semibold mb-4 text-gray-800">
-            Distribución de Bovinos por Edad y Sexo
+            {t('charts.ageSexDistribution')}
           </h3>
           <div className="flex justify-center">
             <svg ref={barrasApiladasRef}></svg>
@@ -632,7 +634,7 @@ export const AnalisisDetallado = ({ animalData, allAnimalData, selectedYear }: A
                   <Calendar className="h-4 w-4 text-white" />
                 </div>
                 <div>
-                  <p className="text-xs text-amber-700 font-medium">Rango de Edad</p>
+                  <p className="text-xs text-amber-700 font-medium">{t('charts.ageRange')}</p>
                   <p className="text-sm font-semibold text-amber-900">
                     {tooltipApiladas.edad}
                   </p>
@@ -644,7 +646,7 @@ export const AnalisisDetallado = ({ animalData, allAnimalData, selectedYear }: A
                   <Activity className="h-4 w-4 text-white" />
                 </div>
                 <div>
-                  <p className="text-xs text-amber-700 font-medium">Total Bovinos</p>
+                  <p className="text-xs text-amber-700 font-medium">{t('charts.totalCattle')}</p>
                   <p className="text-lg font-bold text-amber-900">
                     {tooltipApiladas.total.toLocaleString('es-CO')}
                   </p>
@@ -656,7 +658,7 @@ export const AnalisisDetallado = ({ animalData, allAnimalData, selectedYear }: A
                   <PieChart className="h-4 w-4 text-white" />
                 </div>
                 <div>
-                  <p className="text-xs text-amber-700 font-medium">Porcentaje del Género</p>
+                  <p className="text-xs text-amber-700 font-medium">{t('charts.genderPercentage')}</p>
                   <p className="text-lg font-bold text-amber-900">
                     {tooltipApiladas.porcentaje.toFixed(1)}%
                   </p>
@@ -669,7 +671,7 @@ export const AnalisisDetallado = ({ animalData, allAnimalData, selectedYear }: A
         {/* Gráfico Inferior Izquierdo */}
         <div className="bg-white rounded-lg p-4 border-2 border-green-200 shadow-md relative" ref={containerEdadRef}>
           <h3 className="text-center font-semibold mb-4 text-gray-800">
-            Proporción de Bovinos por Edad
+            {t('charts.ageProportion')}
           </h3>
           <div className="flex justify-center">
             <svg ref={donaEdadRef}></svg>
@@ -699,7 +701,7 @@ export const AnalisisDetallado = ({ animalData, allAnimalData, selectedYear }: A
                   <Activity className="h-4 w-4 text-white" />
                 </div>
                 <div>
-                  <p className="text-xs text-amber-700 font-medium">Total Bovinos</p>
+                  <p className="text-xs text-amber-700 font-medium">{t('charts.totalCattle')}</p>
                   <p className="text-lg font-bold text-amber-900">
                     {tooltipEdad.total.toLocaleString('es-CO')}
                   </p>
@@ -711,7 +713,7 @@ export const AnalisisDetallado = ({ animalData, allAnimalData, selectedYear }: A
                   <PieChart className="h-4 w-4 text-white" />
                 </div>
                 <div>
-                  <p className="text-xs text-amber-700 font-medium">Porcentaje</p>
+                  <p className="text-xs text-amber-700 font-medium">{t('charts.percentage')}</p>
                   <p className="text-lg font-bold text-amber-900">
                     {tooltipEdad.porcentaje.toFixed(1)}%
                   </p>
@@ -724,7 +726,7 @@ export const AnalisisDetallado = ({ animalData, allAnimalData, selectedYear }: A
         {/* Gráfico Inferior Derecho */}
         <div className="bg-white rounded-lg p-4 border-2 border-pink-200 shadow-md relative" ref={containerSexoRef}>
           <h3 className="text-center font-semibold mb-4 text-gray-800">
-            Proporción de Bovinos por Sexo
+            {t('charts.sexProportion')}
           </h3>
           <div className="flex justify-center">
             <svg ref={donaSexoRef}></svg>
@@ -754,7 +756,7 @@ export const AnalisisDetallado = ({ animalData, allAnimalData, selectedYear }: A
                   <Activity className="h-4 w-4 text-white" />
                 </div>
                 <div>
-                  <p className="text-xs text-amber-700 font-medium">Total Bovinos</p>
+                  <p className="text-xs text-amber-700 font-medium">{t('charts.totalCattle')}</p>
                   <p className="text-lg font-bold text-amber-900">
                     {tooltipSexo.total.toLocaleString('es-CO')}
                   </p>
@@ -766,7 +768,7 @@ export const AnalisisDetallado = ({ animalData, allAnimalData, selectedYear }: A
                   <PieChart className="h-4 w-4 text-white" />
                 </div>
                 <div>
-                  <p className="text-xs text-amber-700 font-medium">Porcentaje</p>
+                  <p className="text-xs text-amber-700 font-medium">{t('charts.percentage')}</p>
                   <p className="text-lg font-bold text-amber-900">
                     {tooltipSexo.porcentaje.toFixed(1)}%
                   </p>

--- a/src/components/dashboard/DashboardHeader.tsx
+++ b/src/components/dashboard/DashboardHeader.tsx
@@ -1,7 +1,8 @@
-import { Activity } from 'lucide-react';
 import cattleIcon from '@/assets/cattle-icon.png';
+import { useI18n } from '@/lib/i18n';
 
 export const DashboardHeader = () => {
+  const { t } = useI18n();
   return (
     <header className="bg-card border-b-0 shadow-md fixed top-0 left-0 right-0 z-50">
       <div className="container mx-auto px-6 py-3">
@@ -12,7 +13,7 @@ export const DashboardHeader = () => {
             className="w-10 h-10 object-contain drop-shadow-sm"
           />
           <h1 className="text-2xl font-bold text-foreground tracking-wide">
-            Sistema de Análisis Ganadero Bovino
+            {t('header.title')}
           </h1>
         </div>
       </div>

--- a/src/components/dashboard/KPICards.tsx
+++ b/src/components/dashboard/KPICards.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Activity, Building2, TrendingUp, MapPin } from 'lucide-react';
 import { AnimalData, FarmData } from '@/types/dashboard';
+import { useI18n } from '@/lib/i18n';
 
 interface KPICardsProps {
   animalData: AnimalData[];
@@ -9,6 +10,7 @@ interface KPICardsProps {
 }
 
 export const KPICards = ({ animalData, farmData, selectedYear }: KPICardsProps) => {
+  const { t } = useI18n();
   const yearData = animalData.filter(item => item.AÑO === selectedYear);
   const yearFarmData = farmData.filter(item => item.AÑO === selectedYear);
   
@@ -21,25 +23,25 @@ export const KPICards = ({ animalData, farmData, selectedYear }: KPICardsProps) 
 
   const kpis = [
     {
-      title: "Total Bovinos",
+      title: t('kpi.totalCattle'),
       value: totalAnimals.toLocaleString('es-CO'),
       icon: Activity,
       color: "text-amber-700"
     },
     {
-      title: "Total Fincas",
+      title: t('kpi.totalFarms'),
       value: totalFarms.toLocaleString('es-CO'),
       icon: Building2,
       color: "text-amber-600"
     },
     {
-      title: "Promedio por Finca",
+      title: t('kpi.averagePerFarm'),
       value: avgAnimalsPerFarm.toLocaleString('es-CO'),
       icon: TrendingUp,
       color: "text-orange-600"
     },
     {
-      title: "Departamentos",
+      title: t('kpi.departments'),
       value: uniqueDepartments.toString(),
       icon: MapPin,
       color: "text-yellow-700"

--- a/src/components/dashboard/RankingDepartamentos.tsx
+++ b/src/components/dashboard/RankingDepartamentos.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import * as d3 from 'd3';
 import { AnimalData, FarmData } from '@/types/dashboard';
 import { MapPin, TrendingUp, Activity, Building2 } from 'lucide-react';
+import { useI18n } from '@/lib/i18n';
 
 interface RankingDepartamentosProps {
   animalData: AnimalData[];
@@ -10,6 +11,7 @@ interface RankingDepartamentosProps {
 }
 
 export const RankingDepartamentos = ({ animalData, farmData, selectedYear }: RankingDepartamentosProps) => {
+  const { t } = useI18n();
   const svgRef = useRef<SVGSVGElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [tooltip, setTooltip] = useState<{
@@ -308,7 +310,7 @@ export const RankingDepartamentos = ({ animalData, farmData, selectedYear }: Ran
                 <Activity className="h-4 w-4 text-white" />
               </div>
               <div>
-                <p className="text-xs text-amber-700 font-medium">Total Bovinos</p>
+                <p className="text-xs text-amber-700 font-medium">{t('charts.totalCattle')}</p>
                 <p className="text-lg font-bold text-amber-900">
                   {tooltip.totalBovinos.toLocaleString('es-CO')}
                 </p>
@@ -320,7 +322,7 @@ export const RankingDepartamentos = ({ animalData, farmData, selectedYear }: Ran
                 <Building2 className="h-4 w-4 text-white" />
               </div>
               <div>
-                <p className="text-xs text-amber-700 font-medium">Total Fincas</p>
+                <p className="text-xs text-amber-700 font-medium">{t('charts.totalFarms')}</p>
                 <p className="text-sm font-bold text-amber-900">
                   {tooltip.totalFincas.toLocaleString('es-CO')}
                 </p>
@@ -332,9 +334,9 @@ export const RankingDepartamentos = ({ animalData, farmData, selectedYear }: Ran
                 <TrendingUp className="h-4 w-4 text-white" />
               </div>
               <div>
-                <p className="text-xs text-amber-700 font-medium">Promedio por Finca</p>
+                <p className="text-xs text-amber-700 font-medium">{t('charts.averagePerFarm')}</p>
                 <p className="text-sm font-bold text-amber-900">
-                  {tooltip.promedioFinca.toLocaleString('es-CO', { maximumFractionDigits: 1 })} bovinos
+                  {tooltip.promedioFinca.toLocaleString('es-CO', { maximumFractionDigits: 1 })} {t('charts.cattle')}
                 </p>
               </div>
             </div>

--- a/src/components/dashboard/RankingMunicipios.tsx
+++ b/src/components/dashboard/RankingMunicipios.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import * as d3 from 'd3';
 import { AnimalData, FarmData } from '@/types/dashboard';
 import { Activity, MapPin, TrendingUp, Building2 } from 'lucide-react';
+import { useI18n } from '@/lib/i18n';
 
 interface RankingMunicipiosProps {
   animalData: AnimalData[];
@@ -29,6 +30,7 @@ interface TooltipState {
 }
 
 export const RankingMunicipios = ({ animalData, farmData, selectedYear }: RankingMunicipiosProps) => {
+  const { t } = useI18n();
   const svgRef = useRef<SVGSVGElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -429,7 +431,7 @@ export const RankingMunicipios = ({ animalData, farmData, selectedYear }: Rankin
                 <Activity className="h-4 w-4 text-white" />
               </div>
               <div>
-                <p className="text-xs text-amber-700 font-medium">Total Bovinos</p>
+                <p className="text-xs text-amber-700 font-medium">{t('charts.totalCattle')}</p>
                 <p className="text-lg font-bold text-amber-900">
                   {tooltip.totalBovinos.toLocaleString('es-CO')}
                 </p>
@@ -441,7 +443,7 @@ export const RankingMunicipios = ({ animalData, farmData, selectedYear }: Rankin
                 <Building2 className="h-4 w-4 text-white" />
               </div>
               <div>
-                <p className="text-xs text-amber-700 font-medium">Total Fincas</p>
+                <p className="text-xs text-amber-700 font-medium">{t('charts.totalFarms')}</p>
                 <p className="text-sm font-bold text-amber-900">
                   {tooltip.totalFincas.toLocaleString('es-CO')}
                 </p>
@@ -453,9 +455,9 @@ export const RankingMunicipios = ({ animalData, farmData, selectedYear }: Rankin
                 <TrendingUp className="h-4 w-4 text-white" />
               </div>
               <div>
-                <p className="text-xs text-amber-700 font-medium">Promedio por Finca</p>
+                <p className="text-xs text-amber-700 font-medium">{t('charts.averagePerFarm')}</p>
                 <p className="text-sm font-bold text-amber-900">
-                  {tooltip.promedioFinca.toLocaleString('es-CO', { maximumFractionDigits: 1 })} bovinos
+                  {tooltip.promedioFinca.toLocaleString('es-CO', { maximumFractionDigits: 1 })} {t('charts.cattle')}
                 </p>
               </div>
             </div>

--- a/src/components/dashboard/TablaDepartamentos.tsx
+++ b/src/components/dashboard/TablaDepartamentos.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { AnimalData, FarmData } from '@/types/dashboard';
+import { useI18n } from '@/lib/i18n';
 
 interface TablaDepartamentosProps {
   animalData: AnimalData[];
@@ -16,6 +17,7 @@ interface DepartmentSummary {
 }
 
 export const TablaDepartamentos = ({ animalData, farmData, selectedYear }: TablaDepartamentosProps) => {
+  const { t } = useI18n();
   console.log('=== TablaDepartamentos ===');
   console.log('animalData length:', animalData.length);
   console.log('farmData length:', farmData.length);
@@ -99,7 +101,7 @@ export const TablaDepartamentos = ({ animalData, farmData, selectedYear }: Tabla
     <div className="bg-white rounded-lg shadow p-4">
       <div className="bg-green-50 border border-green-200 rounded-lg p-3 mb-4">
         <h3 className="text-sm font-medium text-green-900 text-center">
-          🗂️ Datos por Departamento - {selectedYear}
+          🗂️ {t('tabs.department')} - {selectedYear}
         </h3>
       </div>
 
@@ -107,11 +109,11 @@ export const TablaDepartamentos = ({ animalData, farmData, selectedYear }: Tabla
         <table className="w-full text-sm">
           <thead className="sticky top-0 bg-white">
             <tr className="border-b border-gray-200">
-              <th className="text-left py-2 px-2 font-medium text-gray-700">Departamento</th>
-              <th className="text-right py-2 px-2 font-medium text-gray-700">Total Bovinos</th>
-              <th className="text-right py-2 px-2 font-medium text-gray-700">% Participación</th>
-              <th className="text-right py-2 px-2 font-medium text-gray-700">Total Fincas</th>
-              <th className="text-right py-2 px-2 font-medium text-gray-700">Promedio/Finca</th>
+              <th className="text-left py-2 px-2 font-medium text-gray-700">{t('tabs.department')}</th>
+              <th className="text-right py-2 px-2 font-medium text-gray-700">{t('charts.totalCattle')}</th>
+              <th className="text-right py-2 px-2 font-medium text-gray-700">% {t('charts.percentage')}</th>
+              <th className="text-right py-2 px-2 font-medium text-gray-700">{t('charts.totalFarms')}</th>
+              <th className="text-right py-2 px-2 font-medium text-gray-700">{t('charts.averagePerFarm')}</th>
             </tr>
           </thead>
           <tbody>

--- a/src/components/dashboard/TablaMunicipios.tsx
+++ b/src/components/dashboard/TablaMunicipios.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { AnimalData, FarmData } from '@/types/dashboard';
+import { useI18n } from '@/lib/i18n';
 
 interface TablaMunicipiosProps {
   animalData: AnimalData[];
@@ -18,6 +19,7 @@ interface MunicipalitySummary {
 }
 
 export const TablaMunicipios = ({ animalData, farmData, selectedYear, selectedDepartamento }: TablaMunicipiosProps) => {
+  const { t } = useI18n();
   console.log('=== TablaMunicipios ===');
   console.log('animalData length:', animalData.length);
   console.log('farmData length:', farmData.length);
@@ -116,10 +118,10 @@ export const TablaMunicipios = ({ animalData, farmData, selectedYear, selectedDe
     <div className="bg-white rounded-lg shadow p-4">
       <div className="bg-blue-50 border border-blue-200 rounded-lg p-3 mb-4">
         <h3 className="text-sm font-medium text-blue-900 text-center">
-          🏛️ Datos por Municipio - {selectedYear}
+          🏛️ {t('tabs.municipalities')} - {selectedYear}
           {selectedDepartamento && (
             <span className="block text-xs text-blue-700 mt-1">
-              Departamento: {selectedDepartamento}
+              {t('tabs.department')}: {selectedDepartamento}
             </span>
           )}
         </h3>
@@ -129,14 +131,14 @@ export const TablaMunicipios = ({ animalData, farmData, selectedYear, selectedDe
         <table className="w-full text-sm">
           <thead className="sticky top-0 bg-white">
             <tr className="border-b border-gray-200">
-              <th className="text-left py-2 px-2 font-medium text-gray-700">Municipio</th>
+              <th className="text-left py-2 px-2 font-medium text-gray-700">{t('tabs.municipalities')}</th>
               {!selectedDepartamento && (
-                <th className="text-left py-2 px-2 font-medium text-gray-700">Departamento</th>
+                <th className="text-left py-2 px-2 font-medium text-gray-700">{t('tabs.department')}</th>
               )}
-              <th className="text-right py-2 px-2 font-medium text-gray-700">Total Bovinos</th>
-              <th className="text-right py-2 px-2 font-medium text-gray-700">% Participación</th>
-              <th className="text-right py-2 px-2 font-medium text-gray-700">Total Fincas</th>
-              <th className="text-right py-2 px-2 font-medium text-gray-700">Promedio/Finca</th>
+              <th className="text-right py-2 px-2 font-medium text-gray-700">{t('charts.totalCattle')}</th>
+              <th className="text-right py-2 px-2 font-medium text-gray-700">% {t('charts.percentage')}</th>
+              <th className="text-right py-2 px-2 font-medium text-gray-700">{t('charts.totalFarms')}</th>
+              <th className="text-right py-2 px-2 font-medium text-gray-700">{t('charts.averagePerFarm')}</th>
             </tr>
           </thead>
           <tbody>

--- a/src/components/dashboard/UnifiedNavigation.tsx
+++ b/src/components/dashboard/UnifiedNavigation.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Activity } from 'lucide-react';
 import cattleIcon from '@/assets/cattle-icon.png';
-import { Button } from '@/components/ui/button';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
 import { useI18n } from '@/lib/i18n';
 import {
   DndContext,
@@ -103,7 +103,7 @@ interface UnifiedNavigationProps {
 
 export const UnifiedNavigation = ({ tabs, activeTab, onTabChange }: UnifiedNavigationProps) => {
   const [tabItems, setTabItems] = useState(tabs);
-  const { t, lang, toggleLanguage } = useI18n();
+  const { t, lang, setLanguage } = useI18n();
 
   useEffect(() => {
     setTabItems(tabs);
@@ -145,9 +145,15 @@ export const UnifiedNavigation = ({ tabs, activeTab, onTabChange }: UnifiedNavig
                 {t('header.title')}
               </h1>
             </div>
-            <Button variant="outline" size="sm" onClick={toggleLanguage} className="mt-2 sm:mt-0">
-              {lang === 'en' ? 'ES' : 'EN'}
-            </Button>
+            <Select value={lang} onValueChange={setLanguage}>
+              <SelectTrigger className="w-20 mt-2 sm:mt-0">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="en">EN</SelectItem>
+                <SelectItem value="es">ES</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
         </div>
       </div>

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -5,7 +5,7 @@ type Language = 'en' | 'es';
 const resources = {
   en: {
     header: {
-      title: 'Bovine Livestock Analysis System'
+      title: 'Bovine Livestock Analysis System Colombia'
     },
     tabs: {
       national: 'National Livestock Analysis',
@@ -35,11 +35,33 @@ const resources = {
     },
     metrics: {
       general: 'General Metrics'
+    },
+    kpi: {
+      totalCattle: 'Total Cattle',
+      totalFarms: 'Total Farms',
+      averagePerFarm: 'Average per Farm',
+      departments: 'Departments'
+    },
+    charts: {
+      detailedAnalysis: 'Detailed Metrics Analysis',
+      annualCattle: 'Annual Cattle Numbers',
+      ageSexDistribution: 'Distribution of Cattle by Age and Sex',
+      ageProportion: 'Proportion of Cattle by Age',
+      sexProportion: 'Proportion of Cattle by Sex',
+      year: 'Year',
+      totalCattle: 'Total Cattle',
+      totalFarms: 'Total Farms',
+      averagePerFarm: 'Average per Farm',
+      yoyGrowth: 'YoY Growth',
+      ageRange: 'Age Range',
+      genderPercentage: 'Gender Percentage',
+      percentage: 'Percentage',
+      cattle: 'cattle'
     }
   },
   es: {
     header: {
-      title: 'Sistema de Análisis Ganadero Bovino'
+      title: 'Sistema de Análisis Ganadero Bovino Colombia'
     },
     tabs: {
       national: 'Análisis Ganadero Nacional',
@@ -69,6 +91,28 @@ const resources = {
     },
     metrics: {
       general: 'Métricas Generales'
+    },
+    kpi: {
+      totalCattle: 'Total Bovinos',
+      totalFarms: 'Total Fincas',
+      averagePerFarm: 'Promedio por Finca',
+      departments: 'Departamentos'
+    },
+    charts: {
+      detailedAnalysis: 'Análisis Detallado de Métricas',
+      annualCattle: 'Número de Bovinos Anuales',
+      ageSexDistribution: 'Distribución de Bovinos por Edad y Sexo',
+      ageProportion: 'Proporción de Bovinos por Edad',
+      sexProportion: 'Proporción de Bovinos por Sexo',
+      year: 'Año',
+      totalCattle: 'Total Bovinos',
+      totalFarms: 'Total Fincas',
+      averagePerFarm: 'Promedio por Finca',
+      yoyGrowth: 'Crecimiento YoY',
+      ageRange: 'Rango de Edad',
+      genderPercentage: 'Porcentaje del Género',
+      percentage: 'Porcentaje',
+      cattle: 'bovinos'
     }
   }
 } as const;
@@ -77,6 +121,7 @@ interface I18nContextProps {
   lang: Language;
   t: (key: string, vars?: Record<string, string | number>) => string;
   toggleLanguage: () => void;
+  setLanguage: (lang: Language) => void;
 }
 
 const I18nContext = createContext<I18nContextProps | undefined>(undefined);
@@ -98,9 +143,10 @@ export const I18nProvider = ({ children }: { children: ReactNode }) => {
   };
 
   const toggleLanguage = () => setLang(prev => (prev === 'en' ? 'es' : 'en'));
+  const setLanguage = (language: Language) => setLang(language);
 
   return (
-    <I18nContext.Provider value={{ lang, t, toggleLanguage }}>
+    <I18nContext.Provider value={{ lang, t, toggleLanguage, setLanguage }}>
       {children}
     </I18nContext.Provider>
   );


### PR DESCRIPTION
## Summary
- include Colombia in the dashboard header title
- add a language select dropdown
- internationalize KPI cards, tables, and chart labels for English

## Testing
- `npm run lint` (fails: no-empty-object-type, no-require-imports)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0cf6609b88328909f3d96d7f6a1d7