### PR TITLE
Translate age and sex labels

### DIFF
--- a/src/components/dashboard/AnalisisDetallado.tsx
+++ b/src/components/dashboard/AnalisisDetallado.tsx
@@ -329,7 +329,7 @@ export const AnalisisDetallado = ({ animalData, allAnimalData, selectedYear }: A
       // Ejes
       g.append("g")
         .attr("transform", `translate(0,${height})`)
-        .call(d3.axisBottom(xScale))
+        .call(d3.axisBottom(xScale).tickFormat(d => t(`categories.age.${String(d)}`)))
         .selectAll("text")
         .style("font-size", "10px")
         .style("fill", "#374151")
@@ -625,7 +625,7 @@ export const AnalisisDetallado = ({ animalData, allAnimalData, selectedYear }: A
                   <Users className="h-4 w-4 text-white" />
                 </div>
                 <h4 className="font-semibold text-amber-900 text-sm">
-                  {tooltipApiladas.sexo}
+                  {t(`categories.sex.${tooltipApiladas.sexo}`)}
                 </h4>
               </div>
               
@@ -636,7 +636,7 @@ export const AnalisisDetallado = ({ animalData, allAnimalData, selectedYear }: A
                 <div>
                   <p className="text-xs text-amber-700 font-medium">{t('charts.ageRange')}</p>
                   <p className="text-sm font-semibold text-amber-900">
-                    {tooltipApiladas.edad}
+                    {t(`categories.age.${tooltipApiladas.edad}`)}
                   </p>
                 </div>
               </div>
@@ -692,7 +692,7 @@ export const AnalisisDetallado = ({ animalData, allAnimalData, selectedYear }: A
                   <Calendar className="h-4 w-4 text-white" />
                 </div>
                 <h4 className="font-semibold text-amber-900 text-sm">
-                  {tooltipEdad.edad}
+                  {t(`categories.age.${tooltipEdad.edad}`)}
                 </h4>
               </div>
               
@@ -747,7 +747,7 @@ export const AnalisisDetallado = ({ animalData, allAnimalData, selectedYear }: A
                   <Users className="h-4 w-4 text-white" />
                 </div>
                 <h4 className="font-semibold text-amber-900 text-sm">
-                  {tooltipSexo.sexo}
+                  {t(`categories.sex.${tooltipSexo.sexo}`)}
                 </h4>
               </div>
               

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -57,6 +57,18 @@ const resources = {
       genderPercentage: 'Gender Percentage',
       percentage: 'Percentage',
       cattle: 'cattle'
+    },
+    categories: {
+      age: {
+        'MENOR A 1 AÑO': 'Under 1 Year',
+        '1 - 2 AÑOS': '1 - 2 Years',
+        '2 - 3 AÑOS': '2 - 3 Years',
+        'MAYOR A 3 AÑOS': 'Over 3 Years'
+      },
+      sex: {
+        MACHO: 'Male',
+        HEMBRA: 'Female'
+      }
     }
   },
   es: {
@@ -113,6 +125,18 @@ const resources = {
       genderPercentage: 'Porcentaje del Género',
       percentage: 'Porcentaje',
       cattle: 'bovinos'
+    },
+    categories: {
+      age: {
+        'MENOR A 1 AÑO': 'MENOR A 1 AÑO',
+        '1 - 2 AÑOS': '1 - 2 AÑOS',
+        '2 - 3 AÑOS': '2 - 3 AÑOS',
+        'MAYOR A 3 AÑOS': 'MAYOR A 3 AÑOS'
+      },
+      sex: {
+        MACHO: 'MACHO',
+        HEMBRA: 'HEMBRA'
+      }
     }
   }
 } as const;


### PR DESCRIPTION
## Summary
- add i18n entries for age ranges and sex values
- show translated age and sex labels in detailed analysis charts

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 8 errors, 10 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68a0e0fb85c08328a232817c2a1c0d77