### PR TITLE
feat: specify gender in tooltip for age-sex chart

### DIFF
--- a/src/components/dashboard/AnalisisDetallado.tsx
+++ b/src/components/dashboard/AnalisisDetallado.tsx
@@ -658,7 +658,11 @@ export const AnalisisDetallado = ({ animalData, allAnimalData, selectedYear }: A
                   <PieChart className="h-4 w-4 text-white" />
                 </div>
                 <div>
-                  <p className="text-xs text-amber-700 font-medium">{t('charts.genderPercentage')}</p>
+                  <p className="text-xs text-amber-700 font-medium">
+                    {t('charts.genderPercentage', {
+                      gender: t(`categories.sex.${tooltipApiladas.sexo}`)
+                    })}
+                  </p>
                   <p className="text-lg font-bold text-amber-900">
                     {tooltipApiladas.porcentaje.toFixed(1)}%
                   </p>

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -54,7 +54,7 @@ const resources = {
       averagePerFarm: 'Average per Farm',
       yoyGrowth: 'YoY Growth',
       ageRange: 'Age Range',
-      genderPercentage: 'Gender Percentage',
+      genderPercentage: '{{gender}} Percentage',
       percentage: 'Percentage',
       cattle: 'cattle'
     },
@@ -122,7 +122,7 @@ const resources = {
       averagePerFarm: 'Promedio por Finca',
       yoyGrowth: 'Crecimiento YoY',
       ageRange: 'Rango de Edad',
-      genderPercentage: 'Porcentaje del Género',
+      genderPercentage: 'Porcentaje de {{gender}}',
       percentage: 'Porcentaje',
       cattle: 'bovinos'
     },


### PR DESCRIPTION
## Summary
- show male or female percentage in age/sex chart tooltip
- translate gender percentage labels to include the specific gender

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 8 errors, 10 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0f85f943883288dc36e67c3bf7bc3